### PR TITLE
Remove environment from supervisor conf

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -15,6 +15,5 @@ childlogdir = /tmp
 strip_ansi = false
 
 [program:submitter]
-command=/usr/bin/python /home/ubuntu/eq-submitter/application.py
+command=/usr/local/bin/run_submitter.sh
 autorestart=true
-environment = EQ_RABBITMQ_URL="%(ENV_EQ_RABBITMQ_URL)s",EQ_RABBITMQ_QUEUE_NAME="%(ENV_EQ_RABBITMQ_QUEUE_NAME)s",EQ_SUBMISSIONS_BUCKET_NAME="%(ENV_EQ_SUBMISSIONS_BUCKET_NAME)s",AWS_ACCESS_KEY="%(ENV_AWS_ACCESS_KEY)s",AWS_SECRET_ACCESS_KEY="%(ENV_AWS_SECRET_ACCESS_KEY)s"


### PR DESCRIPTION
**_What**_
Removes the environment line from supervisord.conf as this did not work.  Environment is now provided through a script generated by terraform.

See https://github.com/ONSdigital/eq-terraform/pull/5
